### PR TITLE
Allow script to run forever as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ The code has been migrated from the OctoPrint-WS281x_LED_Status (https://github.
 7. Run script before starting print
    1. ```./klipper-ledstrip.py```
 
+## Directions to run as a systemd service
+
+1. Copy contents of ledstrip.service to /etc/systemd/system/ledstrip.service
+2. Modify User, Group, WorkingDirectory, and ExecStart to match your setup
+3. Run ```systemctl daemon-reload``` to enable the service
+4. Run ```systemctl enable ledstrip``` to have the service start on boot
+
 ### Single run for static colors
+#### Will only work by itself, not if running as a service
 
 ```
 ./klipper-ledstrip.py <red> <green> <blue> <brightness:optiona>

--- a/ledstrip.service
+++ b/ledstrip.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Simplified Python Klipper LED Strip Service
+After=syslog.target
+
+[Service]
+Type=simple
+User=pi
+Group=pi
+WorkingDirectory=/home/pi/Klipper-WS281x_LED_Status/
+ExecStart=/home/pi/Klipper-WS281x_LED_Status/klipper_ledstrip.py
+StandardOutput=syslog
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
- Script will continue running after a print and will start back up again on the next print. Added idle timeout variable to set how long the LEDs will light after a state change.
- Gets base temperatures of the heaters and starts the progress display based on that. This allows the progress to start from the first LED.
- Hopefully fixed issue with heating and print progress trying to display at the same time.