### PR TITLE
Allow configuration of moonraker API host and port

### DIFF
--- a/moonraker_api.py
+++ b/moonraker_api.py
@@ -6,9 +6,9 @@ import math
 import requests
 
 
-def printer_state():
+def printer_state(moonraker_settings):
     ''' Get printer status '''
-    url = 'http://localhost:7125/printer/objects/query?print_stats'
+    url = 'http://' + moonraker_settings['host'] + ':' + str(moonraker_settings['port']) + '/printer/objects/query?print_stats'
     try:
         ret = requests.get(url)
     except requests.exceptions.ConnectionError:
@@ -19,17 +19,17 @@ def printer_state():
         return False
 
 
-def power_status():
+def power_status(moonraker_settings):
     ''' Get printer power status '''
-    url = 'http://localhost:7125/machine/device_power/devices?device=printer'
+    url = 'http://' + moonraker_settings['host'] + ':' + str(moonraker_settings['port']) + '/machine/device_power/devices?device=printer'
     ret = requests.get(url)
     return json.loads(ret.text)['result']['devices'][0]['status']
 
 
 
-def printing_stats(base_temps):
+def printing_stats(moonraker_settings, base_temps):
     ''' Get stats for bed heater, hotend, and printing percent '''
-    url = f'http://localhost:7125/printer/objects/query?heater_bed&extruder&display_status'
+    url = f'http://' + moonraker_settings['host'] + ':' + str(moonraker_settings['port']) + '/printer/objects/query?heater_bed&extruder&display_status'
     data = json.loads(requests.get(url).text)
 
     bed_temp = data['result']['status']['heater_bed']['temperature']
@@ -64,7 +64,7 @@ def heating_percent(temp, target, base_temp):
     return math.floor(((temp - base_temp) * 100) / (target - base_temp))
 
 
-def power_off():
+def power_off(moonraker_settings):
     ''' Power off the printer '''
-    url = 'http://localhost:7125/machine/device_power/off?printer'
+    url = 'http://' + moonraker_settings['host'] + ':' + str(moonraker_settings['port']) + '/machine/device_power/off?printer'
     return requests.post(url).text

--- a/settings.conf
+++ b/settings.conf
@@ -14,6 +14,10 @@ completion_settings:
   bed_temp_for_shutdown   : 50
   hotend_temp_for_shutdown: 40
 
+moonraker_settings:
+  host: 'localhost',
+  port: 7125
+
 ## Available effects: slow_fade, fast_fade, chase, bounce, chase_ghost, ghost_bounce, rainbow
 ##  color format:   [R  , G  , B  ]
 effects:

--- a/settings.conf
+++ b/settings.conf
@@ -15,7 +15,7 @@ completion_settings:
   hotend_temp_for_shutdown: 40
 
 moonraker_settings:
-  host: 'localhost',
+  host: 'localhost'
   port: 7125
 
 ## Available effects: slow_fade, fast_fade, chase, bounce, chase_ghost, ghost_bounce, rainbow


### PR DESCRIPTION
Hi, 

Wanted to thank you for this solution, it works great for me.

I run multiple printers and instances of moonraker off my Pi4, so I just added a quick way to configure the moonraker host/port so that my LED strip could be used to display print status across either printer.